### PR TITLE
Automate manual Fedora/GNOME setup steps

### DIFF
--- a/home/.chezmoiscripts/linux/run_onchange_after_install-gnome-extensions.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_after_install-gnome-extensions.sh.tmpl
@@ -1,0 +1,32 @@
+{{ $extensions := list
+  "clipboard-indicator@tudmotu.com"
+  "hide-minimized@danigm.net" -}}
+
+#!{{ lookPath "bash" }}
+
+set -eufo pipefail
+
+# Install GNOME Shell extensions that are not packaged for Fedora, pulling the
+# build that matches the running shell from extensions.gnome.org.
+shell_version="$(gnome-shell --version | grep -oE '[0-9]+' | head -1)"
+
+for uuid in {{ $extensions | join " " }}; do
+  if ! gnome-extensions list 2>/dev/null | grep -qx "$uuid"; then
+    info="$(curl -fsS "https://extensions.gnome.org/extension-info/?uuid=${uuid}&shell_version=${shell_version}")"
+    path="$(echo "$info" | python3 -c 'import sys,json; print(json.load(sys.stdin)["download_url"])')"
+    tmp="$(mktemp --suffix=.zip)"
+    curl -fsS -o "$tmp" "https://extensions.gnome.org${path}"
+    gnome-extensions install --force "$tmp"
+    rm -f "$tmp"
+  fi
+  # enable() fails until the shell reloads the freshly-installed extension, so
+  # fall back to registering the UUID directly for the next login.
+  gnome-extensions enable "$uuid" 2>/dev/null || {
+    enabled="$(gsettings get org.gnome.shell enabled-extensions)"
+    case "$enabled" in
+      *"'$uuid'"*) ;;
+      "@as []"|"[]") gsettings set org.gnome.shell enabled-extensions "['$uuid']" ;;
+      *) gsettings set org.gnome.shell enabled-extensions "${enabled%]}, '$uuid']" ;;
+    esac
+  }
+done

--- a/home/.chezmoiscripts/linux/run_onchange_before_configure-environment.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_before_configure-environment.sh.tmpl
@@ -1,0 +1,9 @@
+#!{{ lookPath "bash" }}
+
+set -eufo pipefail
+
+# Allow Electron 28 and up apps to run on Wayland.
+if ! grep -q '^ELECTRON_OZONE_PLATFORM_HINT=' /etc/environment 2>/dev/null; then
+  echo '# Allow Electron 28 and up apps to run on Wayland' | {{ template "sudo.tmpl" . }}tee -a /etc/environment >/dev/null
+  echo 'ELECTRON_OZONE_PLATFORM_HINT=auto' | {{ template "sudo.tmpl" . }}tee -a /etc/environment >/dev/null
+fi

--- a/home/.chezmoiscripts/linux/run_onchange_before_configure-gnome.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_before_configure-gnome.sh.tmpl
@@ -4,3 +4,6 @@ set -eufo pipefail
 
 # Disable version-check for gnome extensions.
 gsettings set org.gnome.shell disable-extension-version-validation true
+
+# Enable Maximize and Minimize window buttons (Tweaks > Windows).
+gsettings set org.gnome.desktop.wm.preferences button-layout 'appmenu:minimize,maximize,close'


### PR DESCRIPTION
Automates the three manual Fedora/GNOME steps tracked in #6 so a fresh `chezmoi apply` handles them.

## Changes
- **Window buttons** — `gsettings` enables Maximize/Minimize buttons (Tweaks > Windows), added to the existing `run_onchange_before_configure-gnome.sh.tmpl`.
- **Electron on Wayland** — new `run_onchange_before_configure-environment.sh.tmpl` appends `ELECTRON_OZONE_PLATFORM_HINT=auto` to `/etc/environment` (idempotent, via the `sudo.tmpl` helper).
- **GNOME extensions** — new `run_onchange_after_install-gnome-extensions.sh.tmpl` installs and enables `clipboard-indicator@tudmotu.com` and `hide-minimized@danigm.net` from extensions.gnome.org, pulling the build matching the running shell version. UUID list is a template variable for easy extension.

## Notes
- All scripts live under `.chezmoiscripts/linux/`, already gated to Linux by `.chezmoiignore.tmpl` — no effect on macOS.
- Verified via template rendering + `bash -n`. Not yet run end-to-end on Fedora (authored on Darwin); the extension enable likely takes effect after a re-login.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)