### PR TITLE
fix: harden setup scripts and resolve code-review findings

### DIFF
--- a/home/.chezmoiscripts/linux/fedora/run_onchange_before_configure-dnf.sh.tmpl
+++ b/home/.chezmoiscripts/linux/fedora/run_onchange_before_configure-dnf.sh.tmpl
@@ -8,7 +8,7 @@ CONFIG_FILE="/etc/dnf/dnf.conf"
 
 # Check if the line already exists before appending
 if ! grep -q "^${CONFIG_LINE}$" "$CONFIG_FILE"; then
-    echo "$CONFIG_LINE" | {{ template "sudo.tmpl" . }}tee -a "$CONFIG_FILE" > /dev/null
+  echo "$CONFIG_LINE" | {{ template "sudo.tmpl" . }}tee -a "$CONFIG_FILE" > /dev/null
 fi
 
 # Ensure dnf-plugins-core is installed

--- a/home/.chezmoiscripts/linux/fedora/run_onchange_before_configure-repos.sh.tmpl
+++ b/home/.chezmoiscripts/linux/fedora/run_onchange_before_configure-repos.sh.tmpl
@@ -11,5 +11,8 @@
 set -eufo pipefail
 
 {{ range $repos }}
+{{- if not (hasPrefix "http" .) }}
+# repofile hash: {{ include . | sha256sum }}
+{{- end }}
 {{ template "sudo.tmpl" $ }}dnf config-manager addrepo --overwrite --from-repofile={{ . }}
 {{ end }}

--- a/home/.chezmoiscripts/linux/run_onchange_after_install-gnome-extensions.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_after_install-gnome-extensions.sh.tmpl
@@ -1,3 +1,4 @@
+{{- if (lookPath "gnome-extensions") -}}
 {{ $extensions := list
   "clipboard-indicator@tudmotu.com"
   "hide-minimized@danigm.net" -}}
@@ -30,3 +31,4 @@ for uuid in {{ $extensions | join " " }}; do
     esac
   }
 done
+{{ end -}}

--- a/home/.chezmoiscripts/linux/run_onchange_before_configure-gnome.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_before_configure-gnome.sh.tmpl
@@ -1,3 +1,4 @@
+{{- if (lookPath "gsettings") -}}
 #!{{ lookPath "bash" }}
 
 set -eufo pipefail
@@ -7,3 +8,4 @@ gsettings set org.gnome.shell disable-extension-version-validation true
 
 # Enable Maximize and Minimize window buttons (Tweaks > Windows).
 gsettings set org.gnome.desktop.wm.preferences button-layout 'appmenu:minimize,maximize,close'
+{{ end -}}

--- a/home/.chezmoiscripts/run_onchange_after_build-bat-cache.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_build-bat-cache.sh.tmpl
@@ -1,6 +1,8 @@
 {{- if (lookPath "bat") -}}
 #!{{ lookPath "bash" }}
 
+set -eufo pipefail
+
 # themeConfigFile hash: {{ include (joinPath .chezmoi.homeDir ".config/bat/themes/Catppuccin Latte.tmTheme") | sha256sum }}
 # bat version: {{ output "bat" "--version" | trim }}
 bat cache --build >/dev/null

--- a/home/.chezmoiscripts/run_onchange_after_chsh.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_chsh.sh.tmpl
@@ -1,8 +1,18 @@
 {{- if (lookPath "fish") -}}
 #!{{ lookPath "bash" }}
 
-if [[ "$SHELL" != "$(which fish)" ]]; then
-    {{ template "sudo.tmpl" . }}chsh -s "$(which fish)" "$(whoami)"
+set -eufo pipefail
+
+fish_path="$(command -v fish)"
+
+# chsh refuses a shell that isn't listed in /etc/shells, and Homebrew does not
+# register its fish there, so add it before switching.
+if ! grep -qxF "$fish_path" /etc/shells; then
+    echo "$fish_path" | {{ template "sudo.tmpl" . }}tee -a /etc/shells >/dev/null
+fi
+
+if [[ "${SHELL:-}" != "$fish_path" ]]; then
+    {{ template "sudo.tmpl" . }}chsh -s "$fish_path" "$(whoami)"
 fi
 
 {{ end -}}

--- a/home/dot_config/private_fish/conf.d/00-env.fish.tmpl
+++ b/home/dot_config/private_fish/conf.d/00-env.fish.tmpl
@@ -18,7 +18,7 @@ set -gx GPG_TTY (tty)
 set -gx LANG en_US.utf-8
 set -gx GH_TELEMETRY false
 
-set -Ux FZF_DEFAULT_OPTS "\
+set -gx FZF_DEFAULT_OPTS "\
 --color=bg+:#ccd0da,bg:#eff1f5,spinner:#dc8a78,hl:#d20f39 \
 --color=fg:#4c4f69,header:#d20f39,info:#8839ef,pointer:#dc8a78 \
 --color=marker:#dc8a78,fg+:#4c4f69,prompt:#8839ef,hl+:#d20f39"

--- a/home/dot_config/private_fish/conf.d/20-mise.fish.tmpl
+++ b/home/dot_config/private_fish/conf.d/20-mise.fish.tmpl
@@ -1,9 +1,9 @@
 if type -q mise
     if test "$VSCODE_RESOLVING_ENVIRONMENT" = 1
-    {{ lookPath "mise" }} activate fish --shims | source
+        {{ lookPath "mise" }} activate fish --shims | source
     else if status is-interactive
-    {{ lookPath "mise" }} activate fish | source
+        {{ lookPath "mise" }} activate fish | source
     else
-    {{ lookPath "mise" }} activate fish --shims | source
+        {{ lookPath "mise" }} activate fish --shims | source
     end
 end

--- a/install.sh
+++ b/install.sh
@@ -2,13 +2,7 @@
 
 set -Eeuo pipefail
 
-declare -r DOTFILES_REPO_URL="https://github.com/caycehouse/dotfiles"
-
-function get_os_type() {
-  uname
-}
-
-declare ostype="$(get_os_type)"
+ostype="$(uname)"
 if [ "${ostype}" == "Darwin" ]; then
   # Install XCode Command Line Tools if necessary
   declare git_cmd_path="/Library/Developer/CommandLineTools/usr/bin/git"
@@ -37,7 +31,7 @@ elif [ "${ostype}" == "Linux" ]; then
   fi
 else
     echo "Unknown OS type: ${ostype}"
-    return 1
+    exit 1
 fi
 
 # Install Homebrew if necessary


### PR DESCRIPTION
Post-review hardening pass over the codebase, scoped to the fixes agreed during review (security/cosmetic items I'd flagged but you weren't concerned about — SSH host-key checking, `rpm --nodigest`, the Rosetta arch guard, and the atuin secret handling — were intentionally left as-is on `main`).

## Correctness
- **GNOME scripts no longer break headless `chezmoi apply`** — guarded `install-gnome-extensions` (`lookPath "gnome-extensions"`) and `configure-gnome` (`lookPath "gsettings"`); they previously ran on *all* Linux and aborted apply where GNOME isn't present (Codespaces/servers).
- **chsh** — register fish in `/etc/shells` before switching (Homebrew doesn't), and add `set -e`. Fixes the default-shell change silently failing on a *fresh* machine; it's a no-op where fish is already registered.
- **install.sh** — `return 1` → `exit 1` at top level.

## Conventions / hygiene
- **configure-repos** — hash each local `.repo` asset *inside the range*, so edits re-trigger the script and newly added repos are picked up automatically (no manual hash line to maintain). Remote URL entries are skipped.
- **install.sh** — drop unused `DOTFILES_REPO_URL`, inline `get_os_type`.
- `-gx` (not `-Ux`) for `FZF_DEFAULT_OPTS`; add `set -e` to bat-cache; fix editorconfig indentation in `configure-dnf` and `20-mise`.

## Verification
- All modified templates render via `chezmoi execute-template`; the two GNOME scripts correctly render empty on a non-GNOME host, and configure-repos emits a per-asset hash comment.
- `install.sh` and the rendered `chsh` script pass `shellcheck -S warning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)